### PR TITLE
makaelas-project-page-edits: Project detail page polish

### DIFF
--- a/app/components/ProjectDetailPage.tsx
+++ b/app/components/ProjectDetailPage.tsx
@@ -35,6 +35,13 @@ export default function ProjectDetailPage({ category, slug }: Props) {
             </Link>
             <p className="eyebrow">{project.client}</p>
             <h1 className="section-title">{project.title}</h1>
+            {meta.length > 0 && (
+              <p className="project-detail-meta-line">
+                {meta.map(({ value }, i) => (
+                  <span key={i}>{i > 0 && <span className="project-detail-meta-sep"> · </span>}{value}</span>
+                ))}
+              </p>
+            )}
             {project.watchUrl && (
               <a
                 href={project.watchUrl}
@@ -63,24 +70,14 @@ export default function ProjectDetailPage({ category, slug }: Props) {
         </div>
       </section>
 
-      {/* ── Meta + Description ──────────────────────────────────── */}
-      <section className="section-dark" style={{ paddingTop: '0', paddingBottom: 'clamp(3rem, 6vw, 5rem)' }}>
-        <div className="container">
-          <div className="project-detail-body">
-            <div className="project-detail-meta">
-              {meta.map(({ label, value }) => (
-                <div key={label} className="project-detail-meta-item">
-                  <p className="project-detail-meta-label">{label}</p>
-                  <p className="project-detail-meta-value">{value}</p>
-                </div>
-              ))}
-            </div>
-            {project.description && (
-              <p className="project-detail-description">{project.description}</p>
-            )}
+      {/* ── Description ─────────────────────────────────────────── */}
+      {project.description && (
+        <section className="section-dark" style={{ paddingTop: '0', paddingBottom: 'clamp(3rem, 6vw, 5rem)' }}>
+          <div className="container">
+            <p className="project-detail-description">{project.description}</p>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       {/* ── Gallery ─────────────────────────────────────────────── */}
       {project.images && project.images.length > 0 && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -402,8 +402,19 @@ ul { list-style: none; }
 .project-detail-header {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
   padding-bottom: clamp(1.5rem, 3vw, 2.5rem);
+}
+.project-detail-meta-line {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rosy-brown);
+}
+.project-detail-meta-sep {
+  color: rgba(211, 150, 140, 0.4);
 }
 .project-detail-back {
   font-family: var(--font-body);


### PR DESCRIPTION
## Summary
- Project details (client, type, year, role, etc.) now appear as a compact horizontal line under the project title, above the image
- Styled in rosy-brown with faded dot separators
- Removed old vertical meta sidebar below the image
- Description section kept below image

## Test plan
- [ ] Meta line appears under title on project detail pages
- [ ] All available fields (client, type, year, role, studio, director) show correctly
- [ ] No meta line shown if no fields exist
- [ ] Description still renders below image

🤖 Generated with [Claude Code](https://claude.com/claude-code)