### PR TITLE
makaelas-contact-edits: Contact page polish

### DIFF
--- a/app/components/ContactLinks.tsx
+++ b/app/components/ContactLinks.tsx
@@ -8,6 +8,7 @@ type ContactLink = {
   href: string;
   copyText: string;
   icon: React.ReactNode;
+  plainValue?: boolean;
 };
 
 function CopyButton({ text }: { text: string }) {
@@ -42,26 +43,38 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
+const ArrowIcon = () => (
+  <svg className="contact-link-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M7 17L17 7M17 7H7M17 7v10" />
+  </svg>
+);
+
 export default function ContactLinks({ links }: { links: ContactLink[] }) {
   return (
     <div className="contact-links">
-      {links.map(({ label, value, href, copyText, icon }) => (
+      {links.map(({ label, value, href, copyText, icon, plainValue }) => (
         <div key={label} className="contact-link-row">
-          <a
-            href={href}
-            className="contact-link-main"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="contact-link-left">
-              <span className="contact-link-icon">{icon}</span>
-              <span className="contact-link-label eyebrow">{label}</span>
+          {plainValue ? (
+            <div className="contact-link-main contact-link-main--split">
+              <a href={href} target="_blank" rel="noopener noreferrer" className="contact-link-left contact-link-left--link">
+                <span className="contact-link-icon">{icon}</span>
+                <span className="contact-link-label eyebrow">{label}</span>
+              </a>
+              <span className="contact-link-value">{value}</span>
+              <a href={href} target="_blank" rel="noopener noreferrer" className="contact-link-arrow-link">
+                <ArrowIcon />
+              </a>
             </div>
-            <span className="contact-link-value">{value}</span>
-            <svg className="contact-link-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M7 17L17 7M17 7H7M17 7v10" />
-            </svg>
-          </a>
+          ) : (
+            <a href={href} className="contact-link-main" target="_blank" rel="noopener noreferrer">
+              <div className="contact-link-left">
+                <span className="contact-link-icon">{icon}</span>
+                <span className="contact-link-label eyebrow">{label}</span>
+              </div>
+              <span className="contact-link-value">{value}</span>
+              <ArrowIcon />
+            </a>
+          )}
           <CopyButton text={copyText} />
         </div>
       ))}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -20,18 +20,13 @@ export default function Footer() {
 
           <div className="footer-right">
             <nav aria-label="Contact links" className="footer-contact">
-              <a
-                href="https://mail.google.com/mail/?view=cm&to=makaela.johnston@gmail.com"
-                className="footer-contact-item"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <span className="footer-contact-item">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <rect x="2" y="4" width="20" height="16" rx="2" />
                   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
                 </svg>
                 <span>makaela.johnston@gmail.com</span>
-              </a>
+              </span>
               <a
                 href="https://www.instagram.com/heyyheyyitsmj/"
                 className="footer-contact-item"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,6 +13,7 @@ const links = [
     value: 'makaela.johnston@gmail.com',
     href: 'https://mail.google.com/mail/?view=cm&to=makaela.johnston@gmail.com',
     copyText: 'makaela.johnston@gmail.com',
+    plainValue: true,
     icon: (
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <rect x="2" y="4" width="20" height="16" rx="2" />
@@ -51,7 +52,7 @@ export default function Contact() {
     <div>
       <section
         className="section-dark"
-        style={{ paddingTop: 'calc(var(--nav-height) + clamp(3rem, 8vw, 6rem))', paddingBottom: 'clamp(5rem, 12vw, 10rem)' }}
+        style={{ paddingTop: 'calc(var(--nav-height) + clamp(3rem, 8vw, 6rem))' }}
       >
         <div className="container">
           <div className="contact-layout">
@@ -60,7 +61,7 @@ export default function Contact() {
               <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
                 <p className="eyebrow">Contact</p>
                 <h1 className="section-title">
-                  Let&rsquo;s work<br /><em>together</em>
+                  Let&rsquo;s build something<br /><em>worth watching</em>
                 </h1>
                 <div style={{ width: '2.5rem', height: '1px', backgroundColor: 'var(--rosy-brown)' }} />
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -683,19 +683,19 @@ ul { list-style: none; }
 /* ── Shared section utilities ──────────────────────────────────── */
 .section-dark {
   background-color: var(--dark-green);
-  padding: clamp(2.5rem, 6vw, 5rem) 0;
+  padding: clamp(2.5rem, 6vw, 5rem) 0 clamp(0.75rem, 1.5vw, 1.25rem);
 }
 .section-projects {
   background-color: #07261a;
-  padding: clamp(2.5rem, 6vw, 5rem) 0;
+  padding: clamp(2.5rem, 6vw, 5rem) 0 clamp(1.5rem, 3vw, 2.5rem);
 }
 .section-light {
   background-color: var(--beige);
-  padding: clamp(2.5rem, 6vw, 5rem) 0;
+  padding: clamp(2.5rem, 6vw, 5rem) 0 clamp(1.5rem, 3vw, 2.5rem);
 }
 .section-mid {
   background-color: var(--midnight-green);
-  padding: clamp(2rem, 5vw, 4rem) 0;
+  padding: clamp(2rem, 5vw, 4rem) 0 clamp(1rem, 2.5vw, 2rem);
 }
 .eyebrow {
   font-family: var(--font-body);
@@ -920,6 +920,24 @@ ul { list-style: none; }
   color: var(--rosy-brown);
   transform: translate(2px, -2px);
 }
+.contact-link-main--split {
+  cursor: default;
+}
+.contact-link-main--split:hover { opacity: 1; }
+.contact-link-left--link {
+  text-decoration: none;
+  transition: opacity 200ms ease;
+}
+.contact-link-left--link:hover { opacity: 0.65; }
+.contact-link-arrow-link {
+  display: flex;
+  align-items: center;
+  color: rgba(247, 244, 213, 0.3);
+  transition: color 200ms ease, transform 200ms ease;
+  flex-shrink: 0;
+}
+.contact-link-arrow-link:hover { color: var(--rosy-brown); }
+.contact-link-arrow-link:hover .contact-link-arrow { transform: translate(2px, -2px); }
 .copy-btn {
   display: flex;
   align-items: center;
@@ -979,7 +997,7 @@ ul { list-style: none; }
 .footer {
   background-color: rgba(0, 0, 0, 0.25);
   border-top: 1px solid rgba(131, 153, 88, 0.15);
-  padding: 0 0 clamp(1.5rem, 3vw, 2rem);
+  padding: clamp(1.25rem, 2.5vw, 2rem) 0 clamp(1.25rem, 2.5vw, 2rem);
 }
 .footer-inner {
   display: flex;


### PR DESCRIPTION
## Summary
- Updated heading to "Let's build something worth watching"
- Email address is plain selectable text; 'Email' label and arrow → still link to Gmail
- Footer email is plain text, no hyperlink
- Reduced bottom padding on sections site-wide for tighter content-to-footer spacing

## Test plan
- [ ] Contact heading reads correctly
- [ ] Email address text is selectable/copyable, not a link
- [ ] Clicking 'Email' label or arrow opens Gmail compose
- [ ] Footer email is plain text
- [ ] Spacing before footer looks consistent across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)