### PR TITLE
makaelas-navbar-edits: Match navbar margins to site container

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,9 +102,9 @@ ul { list-style: none; }
   border-bottom: 1px solid rgba(131, 153, 88, 0.2);
 }
 .nav-inner {
-  max-width: 1280px;
+  max-width: 1440px;
   margin: 0 auto;
-  padding: 0 clamp(1.5rem, 5vw, 3rem);
+  padding: 0 clamp(1rem, 3vw, 2rem);
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- Nav inner max-width updated from 1280px → 1440px to match container
- Nav padding updated to `clamp(1rem, 3vw, 2rem)` to match container

## Test plan
- [ ] Navbar left/right edges align with page content on all pages
- [ ] No layout regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)