### PR TITLE
MJ-26: Add Chicago Stars to resume

### DIFF
--- a/app/data/resume.ts
+++ b/app/data/resume.ts
@@ -20,6 +20,15 @@ export const resumeInfo = {
 
 const creditData: Credit[] = [
   {
+    title: 'Chicago Stars — Media Day 2026',
+    role: 'Production Designer',
+    studio: 'Chicago Stars',
+    type: 'Media Day',
+    year: '2026',
+    sortYear: 2026,
+    category: 'Commercial',
+  },
+  {
     title: 'Neil Funk Ring of Honor',
     role: 'Production Design',
     studio: 'Chicago Bulls Media',


### PR DESCRIPTION
## What this does

Adds the Chicago Stars — Media Day 2026 credit to the resume page and downloadable PDF.

## Changes in plain English

The resume/credits page now includes the Chicago Stars project at the top of the list (sorted by year, 2026 sorts first). It shows up under the Commercial filter tab as well as the All tab.

Details can be updated once the full role/studio info is confirmed by the client.

## Test plan
- [ ] Visit `/resume` — confirm Chicago Stars appears at the top of the list
- [ ] Toggle the Commercial filter — confirm it appears there too
- [ ] Download the PDF — confirm it's included

🤖 Generated with [Claude Code](https://claude.com/claude-code)