### PR TITLE
MJ-28: Log 2026-06-23 dev session hours + fix totals

### DIFF
--- a/notes/hours.md
+++ b/notes/hours.md
@@ -17,13 +17,27 @@
 
 | Category | Hours |
 |----------|-------|
-| Development (Claude sessions) | ~12h 43m |
+| Development (Claude sessions) | ~13h 15m |
 | Planning & Collaboration | — |
-| **Total** | **~10h 15m** |
+| **Total** | **~13h 15m** |
 
 ---
 
 ## Log
+
+### June 2026
+
+#### 2026-06-23 — Dev Session (~30m)
+**Time:** 10:25 PM – 10:55 PM EDT
+**Type:** Development
+
+**Work Completed:**
+- 4 new commercial project pages — Chicago Sky × 2026 Rebel Jersey (Production Design, Dropbox video, 11-image gallery), Chicago Bulls — Salute to Derrick Rose (Production Design, YouTube embed, 13-image gallery), Chicago Bulls — Derrick Rose Retirement Banner (Art Director, YouTube embed starting at 1:18, 11-image gallery), Chicago Bulls — Ring of Honor: Neil Funk (Production Design, YouTube embed, 5-image gallery)
+- Coming Soon UX — `ProjectCard` now renders a non-clickable "Coming Soon" state when a project has no header image (no `→` arrow, default cursor, `aria-label` for screen readers); covers 6 commercial + 5 narrative placeholders
+- Scroll-reveal load-consistency investigation — replaced `IntersectionObserver` reveal with mount-time reveal + `prefers-reduced-motion` rule (stashed for separate PR)
+- PR #60 merged to main, deployed to Firebase Hosting
+
+---
 
 ### April 2026
 
@@ -41,7 +55,7 @@
 
 ---
 
-#### 2026-04-06 — Dev Sessions (~4h 3m)
+#### 2026-04-06 — Dev Sessions (~4h 28m)
 **Time 1:** 6:18 PM – 6:44 PM EDT (~26m)
 **Time 2:** 6:53 PM – 10:55 PM EDT (~4h 2m)
 **Type:** Development


### PR DESCRIPTION
## Summary

Adds today's 30m dev session entry to `notes/hours.md` (10:25 PM – 10:55 PM EDT) covering the work shipped in #60, and fixes two pre-existing math bugs in the same file.

## Today's entry

- 4 new commercial project pages — Chicago Sky × 2026 Rebel Jersey + 3 Chicago Bulls tribute features (Salute to Derrick Rose, Retirement Banner, Ring of Honor: Neil Funk)
- Coming Soon UX on `ProjectCard` for the 11 placeholder cards
- Scroll-reveal load-consistency investigation (stashed for follow-up PR)
- PR #60 merged + deployed to Firebase Hosting

## Bug fixes in the same file

- **April 6 header read `~4h 3m`** but its two sub-sessions sum to `4h 28m` (26m + 4h 2m). Corrected to `~4h 28m`.
- **Totals row was internally inconsistent** — Development `~12h 43m` / Total `~10h 15m`. With Planning & Collaboration empty, Total can't be less than Development. Re-summed from each session header: `30m + 2h 28m + 4h 28m + 5h 49m = 13h 15m`. Both rows now read `~13h 15m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)